### PR TITLE
Fix minor issue with year rendering in Calendar.tsx

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -154,7 +154,7 @@ const CalendarHeader = ({
 						]
 					}
 				</span>
-				<span className="font-light">{YEAR}</span>
+				{!isNaN(YEAR) ? <span className="font-light">{YEAR}</span> : null}
 			</h2>
 			<div className="flex">
 				{actionButtons.map((a) => (


### PR DESCRIPTION


### Description
Check if YEAR is a valid number. If YEAR is not a number, then just do not render the span tag.

### Changes Made
Just one line in Calendar.tsx

### Related Issues
N/A

### Additional Notes
N/A

## Before
![before](https://github.com/user-attachments/assets/528657d3-e4cd-480b-8d98-a08f406014d8)
## After
![after](https://github.com/user-attachments/assets/da082dab-36a7-4acb-b90b-23357daf8bb7)

