### PR TITLE
fix: Update CourseCard key generation

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -376,9 +376,9 @@ const CalendarCourseOtherTimes = ({
 							height: calcHoursDuration(time.time) * blockHeight + 'rem',
 						}}
 					>
-						{time.classes.map((c) => (
+						{time.classes.map((c, index) => (
 							<CourseTimePlaceholderCard
-								key={c.number}
+								key={`${course.id}-${course.classTypeId}-${c.number}-${c.location}-${index}`}
 								courseId={course.id}
 								classNumber={c.number}
 								classTypeId={course.classTypeId}


### PR DESCRIPTION
### Description
Fix duplicate course rendering when dragging a course.

### Changes Made
Ensure unique keys for CourseCard in CalendarCourses by including id, classTypeId, classNumber, location, and index.

### Related Issues
Fixes #44 

### Additional Notes
Previous key (id + classTypeId) collided for multi-activity courses at the same time, causing duplication on re-render during drag operations.

Console shows this warning when dragging multi-activity courses because duplicate keys cause duplicate rendering.
<img width="763" height="47" alt="image" src="https://github.com/user-attachments/assets/bc918a95-433c-4e0d-8a2e-1fd08c48d639" />
