### PR TITLE
fix: Allow adding classes with adblock

### DIFF
--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -78,12 +78,14 @@ export const SearchForm = () => {
 		const course = courses?.find((c) => c.id === selectedCourseId);
 		if (!course) return;
 		const name = `$${course.name.code}`;
-		await umami.track('Add course', { subject: course.name.subject, name });
 		enrolledCourses.addCourse({
 			name,
 			id: course.id,
 		});
 		setSelectedCourseId(null);
+		if (typeof umami !== 'undefined') {
+			await umami.track('Add course', { subject: course.name.subject, name });
+		}
 	};
 
 	return (


### PR DESCRIPTION
### Description
Fixes adding courses with adblock on certain browsers.

### Changes Made
Adds a definition check for umami before attempting to track course add.

### Related Issues
#63 

### Additional Notes
N/A
