### PR TITLE
feat: Implement Share Timetable feature [reopened]

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Footer } from './components/Footer';
 import { Header } from './components/Header';
 import { HelpModal } from './components/HelpModal';
 import { SearchForm } from './components/SearchForm';
+import SharedCalendar from './components/SharedCalendar';
 import { ZoomButtons } from './components/ZoomButtons';
 import { useCoursesInfo } from './data/course-info';
 import { useFirstTimeHelp } from './helpers/help-modal';
@@ -16,6 +17,7 @@ export const App = () => {
 		<>
 			<Header />
 			<main className="mx-auto max-w-(--breakpoint-xl) space-y-4 px-2 py-4">
+				<SharedCalendar />
 				<HelpModal />
 				<ZoomButtons />
 				<SearchForm />

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -2,25 +2,24 @@ import { Button, Tooltip, useDisclosure } from '@heroui/react';
 import clsx from 'clsx';
 import { useEffect, useRef, useState, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FaShare } from 'react-icons/fa';
 import { toast } from 'sonner';
 import { create } from 'zustand';
 
+import { LocalStorageKey } from '../constants/local-storage-keys';
 import { WEEK_DAYS } from '../constants/week-days';
 import { YEAR } from '../constants/year';
 import {
 	useCourseColor,
 	useEnrolledCourse,
 	useEnrolledCourses,
+	useDetailedEnrolledCourses,
 } from '../data/enrolled-courses';
-import { useDetailedEnrolledCourses } from '../data/enrolled-courses';
 import { useSharedTimetable } from '../data/shared-timetable';
 import { useCalendar, useOtherWeekCourseTimes } from '../helpers/calendar';
 import { useCalendarHourHeight } from '../helpers/calendar-hour-height';
 import { findConflicts } from '../helpers/conflicts';
-import { useHelpModal } from '../helpers/help-modal';
 import { calcHoursDuration } from '../helpers/hours-duration';
-import { decodeTimetablefromBase64, generateShareURL } from '../helpers/share';
+import { decodeTimetableFromBase64, generateShareURL } from '../helpers/share';
 import { useZoom } from '../helpers/zoom';
 import type dayjs from '../lib/dayjs';
 import type { DateTimeRange, WeekCourse, WeekCourses } from '../types/course';
@@ -196,7 +195,7 @@ const CalendarHeader = ({
 		sharedTimetableAvailable,
 		setSharedTimetableAvailable,
 	} = useSharedTimetable();
-	const firstTime = useHelpModal().isOpen;
+	const firstTime = localStorage.getItem(LocalStorageKey.FirstTime) === 'true';
 
 	const actionButtons = [
 		{
@@ -226,17 +225,30 @@ const CalendarHeader = ({
 	];
 
 	useEffect(() => {
+		const readDataEncodedInHash = (): void => {
+			const hash = window.location.hash.slice(1);
+			const hashParams = new URLSearchParams(hash);
+			const encodedData = hashParams.get('ed') ?? null;
+			if (!encodedData) return;
+			const decoded = decodeTimetableFromBase64(encodedData);
+			setSharedTimetableData(decoded?.courses ?? null);
+			setSharedTimetableAvailable(decoded ? true : false);
+		};
+
 		const urlParams: URLSearchParams = new URLSearchParams(
 			window.location.search,
 		);
 		const sharedCalendar = urlParams.get('share') === 'true';
+
+		// sets data on mount
 		if (sharedCalendar) {
-			const encodedData = urlParams.get('ed') ?? null;
-			if (!encodedData) return;
-			const decoded = decodeTimetablefromBase64(encodedData);
-			setSharedTimetableData(decoded?.courses ?? null);
-			setSharedTimetableAvailable(decoded ? true : false);
+			readDataEncodedInHash();
 		}
+
+		// when encoded data changes, data is reset
+		window.addEventListener('hashchange', readDataEncodedInHash);
+		return () =>
+			window.removeEventListener('hashchange', readDataEncodedInHash);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -341,8 +353,7 @@ const EndActions = () => {
 				className="font-semibold"
 				onPress={handleShare}
 			>
-				{t('calendar.end-actions.share')}
-				<FaShare />
+				{t('calendar.end-actions.share') + ' 🔗'}
 			</Button>
 			<EnrolmentModal
 				isOpen={isReadyModalOpen}

--- a/src/components/SharedCalendar.tsx
+++ b/src/components/SharedCalendar.tsx
@@ -1,0 +1,275 @@
+import { Button } from '@heroui/react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FaPlus, FaTimes } from 'react-icons/fa';
+
+import { COURSE_COLORS } from '../constants/course-colors';
+import { useSharedTimetable } from '../data/shared-timetable';
+import type { SharedCalendarMeeting } from '../helpers/share';
+import { getMeetingsByDay } from '../helpers/share';
+
+type ClassInfoModalProps = {
+	meeting: SharedCalendarMeeting;
+	modalOpen: boolean;
+	setModalOpen: (value: boolean) => void;
+};
+
+const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+
+function formatDateRange(range: { start: string; end: string }) {
+	const [startMonth, startDay] = range.start.split('-');
+	const [endMonth, endDay] = range.end.split('-');
+	const months = [
+		'',
+		'Jan',
+		'Feb',
+		'Mar',
+		'Apr',
+		'May',
+		'Jun',
+		'Jul',
+		'Aug',
+		'Sep',
+		'Oct',
+		'Nov',
+		'Dec',
+	];
+	const startStr = `${parseInt(startDay)} ${months[parseInt(startMonth)]}`;
+	const endStr = `${parseInt(endDay)} ${months[parseInt(endMonth)]}`;
+	return range.start === range.end ? startStr : `${startStr} - ${endStr}`;
+}
+
+function formatTime(time: { start: string; end: string }) {
+	const to12hr = (t: string) => {
+		const [h, m] = t.split(':').map(Number);
+		const ampm = h >= 12 ? 'PM' : 'AM';
+		const hour = h % 12 === 0 ? 12 : h % 12;
+		return `${hour}:${m.toString().padStart(2, '0')} ${ampm}`;
+	};
+	return `${to12hr(time.start)} - ${to12hr(time.end)}`;
+}
+
+function ClassInfoModal({
+	meeting,
+	modalOpen,
+	setModalOpen,
+}: ClassInfoModalProps) {
+	return (
+		modalOpen && (
+			<div className="relative mx-3 my-2 flex flex-col gap-2 rounded-lg">
+				<Button
+					isIconOnly
+					onPress={() => setModalOpen(false)}
+					className="dark:bg-default-100 dark:hover:bg-default-200 absolute -top-1 -right-1 rounded-full bg-slate-100 p-2 hover:bg-slate-200/80"
+				>
+					<FaTimes />
+				</Button>
+				<h1 className="mr-10 text-lg font-bold text-black dark:text-white">
+					{meeting.courseName} - {meeting.title}
+				</h1>
+				<div className="-mt-1 mb-1 flex w-full items-center gap-2">
+					<span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+						{meeting.classType} | Class Number {meeting.classNumber}
+					</span>
+				</div>
+				<div className="dark:bg-default-100 w-full overflow-x-auto rounded-2xl bg-slate-100 p-4">
+					<table className="w-full min-w-[500px] text-left">
+						<thead>
+							<tr className="text-sm text-slate-500 dark:text-slate-300">
+								<th className="px-2 py-2 font-semibold">Dates</th>
+								<th className="px-2 py-2 font-semibold">Day</th>
+								<th className="px-2 py-2 font-semibold">Time</th>
+								<th className="px-2 py-2 font-semibold">Location</th>
+								<th className="px-2 py-2 font-semibold">Campus</th>
+								<th className="px-2 py-2 font-semibold">Availability</th>
+							</tr>
+						</thead>
+						<tbody>
+							{meeting.dateRanges.map((range, idx) => (
+								<tr
+									key={idx}
+									className="text-sm text-slate-800 dark:text-slate-100"
+								>
+									<td className="px-2 py-2">{formatDateRange(range)}</td>
+									<td className="px-2 py-2">{meeting.day || '-'}</td>
+									<td className="px-2 py-2">{formatTime(meeting.time)}</td>
+									<td className="px-2 py-2">{meeting.location}</td>
+									<td className="px-2 py-2">{meeting.campus}</td>
+									<td className="px-2 py-2 font-semibold">
+										<span
+											className={
+												meeting.available_seats === '0' ? 'text-red-500' : ''
+											}
+										>
+											{meeting.available_seats ?? '-'} / {meeting.size ?? '-'}
+										</span>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		)
+	);
+}
+
+export default function SharedCalendar() {
+	const { sharedTimetableData, showSharedTimetable, setShowSharedTimetable } =
+		useSharedTimetable();
+	const [meetingsByDay, setMeetingsByDay] = useState<Record<
+		string,
+		SharedCalendarMeeting[]
+	> | null>(null);
+
+	const [showClassModal, setShowClassModal] = useState(false);
+	const [selectedClassInfo, setSelectedClassInfo] =
+		useState<SharedCalendarMeeting | null>(null);
+
+	const { t } = useTranslation();
+	const DISPLAY_DAYS = t('calendar.week-days', {
+		returnObjects: true,
+	}) as string[];
+
+	let currentColorIndex: number = 0;
+
+	const sharedClassesColors: Map<
+		string,
+		{
+			bg: string;
+			border: string;
+			text: string;
+			dot: string;
+		}
+	> = new Map([]);
+
+	const handleShowClassModal = (classInfo: SharedCalendarMeeting) => {
+		setSelectedClassInfo(classInfo);
+		setShowClassModal(true);
+	};
+
+	useEffect(() => {
+		if (showSharedTimetable) {
+			document.body.style.overflow = 'hidden';
+		} else {
+			document.body.style.overflow = 'unset';
+		}
+	}, [showSharedTimetable]);
+
+	useEffect(() => {
+		if (sharedTimetableData) {
+			// eslint-disable-next-line react-hooks/set-state-in-effect
+			setMeetingsByDay(getMeetingsByDay(sharedTimetableData));
+		}
+	}, [sharedTimetableData]);
+
+	if (!showSharedTimetable) return null;
+
+	return (
+		<div
+			className="fixed inset-0 z-[51] -mb-[16px] flex items-center justify-center bg-black/60"
+			onClick={() => setShowSharedTimetable(false)}
+		>
+			<div
+				className="dark:bg-content1 dark:border-default-200 relative max-h-[80vh] min-h-[450px] w-[80vw] min-w-[375px] scale-95 transform rounded-2xl border-2 border-slate-400 bg-slate-50 shadow-2xl"
+				onClick={(e) => e.stopPropagation()}
+			>
+				<Button
+					isIconOnly
+					onPress={() => setShowSharedTimetable(false)}
+					className="bg-default-100 hover:bg-default-200 absolute top-4 right-4 z-10 rounded-full p-2 transition-colors"
+				>
+					<FaTimes />
+				</Button>
+				<div className="p-6">
+					<h2 className="mb-2 mb-4 text-center text-2xl font-bold tracking-tight text-slate-900 dark:text-white">
+						{t('shared-timetable.title')}
+					</h2>
+					<div className="scrollbar-thin max-h-[65vh] min-h-[350px] w-full overflow-auto pb-4">
+						<div className="grid min-h-[450px] min-w-[1000px] grid-cols-5 gap-3">
+							{meetingsByDay &&
+								DAYS.map((day, idx) => (
+									<div key={day} className="flex flex-col">
+										<div
+											className={`rounded-t-lg py-2 text-center text-base font-semibold`}
+										>
+											{DISPLAY_DAYS[idx]}
+										</div>
+										<div className="mt-1 flex flex-col gap-2">
+											{meetingsByDay[day] && meetingsByDay[day].length === 0 ? (
+												<div className="py-2 text-center text-xs text-slate-500">
+													No classes
+												</div>
+											) : (
+												meetingsByDay[day]?.map(
+													(m: SharedCalendarMeeting, i: number) => {
+														if (
+															!sharedClassesColors.has(
+																`${m.subject}-${m.title}`,
+															)
+														) {
+															sharedClassesColors.set(
+																`${m.subject}-${m.title}`,
+																COURSE_COLORS[currentColorIndex],
+															);
+															currentColorIndex =
+																(currentColorIndex + 1) % COURSE_COLORS.length;
+														}
+														const color = sharedClassesColors.get(
+															`${m.subject}-${m.title}`,
+														)!;
+
+														return (
+															<div
+																key={i}
+																className={`relative rounded-lg border p-2 pb-6 text-xs font-medium shadow-sm ${color.bg} ${color.border} ${color.text} flex flex-col gap-0.5`}
+																style={{ borderLeftWidth: 6 }}
+															>
+																<div className="text-sm font-bold">
+																	<span>{m.courseName + ' '}</span>
+																	<span className="hidden xl:inline-block">
+																		{'- ' + m.classType}
+																	</span>
+																</div>
+																<div>{m.title}</div>
+																<div>{formatTime(m.time)}</div>
+																<Button
+																	isIconOnly
+																	onPress={() => handleShowClassModal(m)}
+																	className="absolute right-1 bottom-1 bg-transparent hover:bg-black/10"
+																	size="sm"
+																>
+																	<FaPlus className="size-2.5" />
+																</Button>
+															</div>
+														);
+													},
+												)
+											)}
+										</div>
+									</div>
+								))}
+						</div>
+					</div>
+				</div>
+				{showClassModal && selectedClassInfo && (
+					<div
+						className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40"
+						onClick={() => setShowClassModal(false)}
+					>
+						<div
+							className="dark:bg-content1 w-full max-w-2xl rounded-2xl bg-white p-4 shadow-2xl"
+							onClick={(e) => e.stopPropagation()}
+						>
+							<ClassInfoModal
+								meeting={selectedClassInfo}
+								modalOpen={showClassModal}
+								setModalOpen={setShowClassModal}
+							/>
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/SharedCalendar.tsx
+++ b/src/components/SharedCalendar.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@heroui/react';
+import dayjs from 'dayjs';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaPlus, FaTimes } from 'react-icons/fa';
 
-import { COURSE_COLORS } from '../constants/course-colors';
 import { useSharedTimetable } from '../data/shared-timetable';
 import type { SharedCalendarMeeting } from '../helpers/share';
 import { getMeetingsByDay } from '../helpers/share';
@@ -15,39 +15,6 @@ type ClassInfoModalProps = {
 };
 
 const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
-
-function formatDateRange(range: { start: string; end: string }) {
-	const [startMonth, startDay] = range.start.split('-');
-	const [endMonth, endDay] = range.end.split('-');
-	const months = [
-		'',
-		'Jan',
-		'Feb',
-		'Mar',
-		'Apr',
-		'May',
-		'Jun',
-		'Jul',
-		'Aug',
-		'Sep',
-		'Oct',
-		'Nov',
-		'Dec',
-	];
-	const startStr = `${parseInt(startDay)} ${months[parseInt(startMonth)]}`;
-	const endStr = `${parseInt(endDay)} ${months[parseInt(endMonth)]}`;
-	return range.start === range.end ? startStr : `${startStr} - ${endStr}`;
-}
-
-function formatTime(time: { start: string; end: string }) {
-	const to12hr = (t: string) => {
-		const [h, m] = t.split(':').map(Number);
-		const ampm = h >= 12 ? 'PM' : 'AM';
-		const hour = h % 12 === 0 ? 12 : h % 12;
-		return `${hour}:${m.toString().padStart(2, '0')} ${ampm}`;
-	};
-	return `${to12hr(time.start)} - ${to12hr(time.end)}`;
-}
 
 function ClassInfoModal({
 	meeting,
@@ -90,9 +57,15 @@ function ClassInfoModal({
 									key={idx}
 									className="text-sm text-slate-800 dark:text-slate-100"
 								>
-									<td className="px-2 py-2">{formatDateRange(range)}</td>
+									<td className="px-2 py-2">
+										{dayjs(range.start).format('D MMM') +
+											' - ' +
+											dayjs(range.end).format('D MMM')}
+									</td>
 									<td className="px-2 py-2">{meeting.day || '-'}</td>
-									<td className="px-2 py-2">{formatTime(meeting.time)}</td>
+									<td className="px-2 py-2">
+										{meeting.time.start + ' - ' + meeting.time.end}
+									</td>
 									<td className="px-2 py-2">{meeting.location}</td>
 									<td className="px-2 py-2">{meeting.campus}</td>
 									<td className="px-2 py-2 font-semibold">
@@ -117,10 +90,6 @@ function ClassInfoModal({
 export default function SharedCalendar() {
 	const { sharedTimetableData, showSharedTimetable, setShowSharedTimetable } =
 		useSharedTimetable();
-	const [meetingsByDay, setMeetingsByDay] = useState<Record<
-		string,
-		SharedCalendarMeeting[]
-	> | null>(null);
 
 	const [showClassModal, setShowClassModal] = useState(false);
 	const [selectedClassInfo, setSelectedClassInfo] =
@@ -131,17 +100,8 @@ export default function SharedCalendar() {
 		returnObjects: true,
 	}) as string[];
 
-	let currentColorIndex: number = 0;
-
-	const sharedClassesColors: Map<
-		string,
-		{
-			bg: string;
-			border: string;
-			text: string;
-			dot: string;
-		}
-	> = new Map([]);
+	const meetingsByDay: Record<string, SharedCalendarMeeting[]> | null =
+		sharedTimetableData ? getMeetingsByDay(sharedTimetableData) : null;
 
 	const handleShowClassModal = (classInfo: SharedCalendarMeeting) => {
 		setSelectedClassInfo(classInfo);
@@ -149,19 +109,8 @@ export default function SharedCalendar() {
 	};
 
 	useEffect(() => {
-		if (showSharedTimetable) {
-			document.body.style.overflow = 'hidden';
-		} else {
-			document.body.style.overflow = 'unset';
-		}
+		document.body.style.overflow = showSharedTimetable ? 'hidden' : 'unset';
 	}, [showSharedTimetable]);
-
-	useEffect(() => {
-		if (sharedTimetableData) {
-			// eslint-disable-next-line react-hooks/set-state-in-effect
-			setMeetingsByDay(getMeetingsByDay(sharedTimetableData));
-		}
-	}, [sharedTimetableData]);
 
 	if (!showSharedTimetable) return null;
 
@@ -203,26 +152,10 @@ export default function SharedCalendar() {
 											) : (
 												meetingsByDay[day]?.map(
 													(m: SharedCalendarMeeting, i: number) => {
-														if (
-															!sharedClassesColors.has(
-																`${m.subject}-${m.title}`,
-															)
-														) {
-															sharedClassesColors.set(
-																`${m.subject}-${m.title}`,
-																COURSE_COLORS[currentColorIndex],
-															);
-															currentColorIndex =
-																(currentColorIndex + 1) % COURSE_COLORS.length;
-														}
-														const color = sharedClassesColors.get(
-															`${m.subject}-${m.title}`,
-														)!;
-
 														return (
 															<div
 																key={i}
-																className={`relative rounded-lg border p-2 pb-6 text-xs font-medium shadow-sm ${color.bg} ${color.border} ${color.text} flex flex-col gap-0.5`}
+																className={`relative rounded-lg border p-2 pb-6 text-xs font-medium shadow-sm ${m.color.bg} ${m.color.border} ${m.color.text} flex flex-col gap-0.5`}
 																style={{ borderLeftWidth: 6 }}
 															>
 																<div className="text-sm font-bold">
@@ -232,7 +165,7 @@ export default function SharedCalendar() {
 																	</span>
 																</div>
 																<div>{m.title}</div>
-																<div>{formatTime(m.time)}</div>
+																<div>{m.time.start + ' - ' + m.time.end}</div>
 																<Button
 																	isIconOnly
 																	onPress={() => handleShowClassModal(m)}

--- a/src/data/shared-timetable.ts
+++ b/src/data/shared-timetable.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+import type { DetailedEnrolledCourse } from '../types/course';
+
+type SharedTimetableState = {
+	sharedTimetableData: DetailedEnrolledCourse[] | null;
+	setSharedTimetableData: (value: DetailedEnrolledCourse[] | null) => void;
+	showSharedTimetable: boolean;
+	setShowSharedTimetable: (value: boolean) => void;
+	sharedTimetableAvailable: boolean;
+	setSharedTimetableAvailable: (value: boolean) => void;
+};
+
+export const useSharedTimetable = create<SharedTimetableState>((set) => ({
+	sharedTimetableData: null,
+	setSharedTimetableData: (data) => set({ sharedTimetableData: data }),
+	showSharedTimetable: false,
+	setShowSharedTimetable: (data: boolean) => set({ showSharedTimetable: data }),
+	sharedTimetableAvailable: false,
+	setSharedTimetableAvailable: (data: boolean) =>
+		set({ sharedTimetableAvailable: data }),
+}));

--- a/src/helpers/share.ts
+++ b/src/helpers/share.ts
@@ -1,0 +1,109 @@
+import type { useDetailedEnrolledCourses } from '../data/enrolled-courses';
+
+export type SharedCalendarMeeting = {
+	available_seats: string;
+	campus: string;
+	classNumber: string;
+	classType: string;
+	courseName: string;
+	date: { start: string; end: string };
+	dateRanges: Array<{ start: string; end: string }>;
+	day: string;
+	location: string;
+	size: string;
+	subject: string;
+	time: { start: string; end: string };
+	title: string;
+};
+
+type SharedCalendarMeetingInternal = SharedCalendarMeeting & { _key: string };
+
+const encodeTimetabletoBase64 = (
+	courses: ReturnType<typeof useDetailedEnrolledCourses>,
+): string => {
+	const shareData = {
+		courses,
+	};
+	const jsonString = JSON.stringify(shareData);
+	const base64 = btoa(jsonString);
+	return base64;
+};
+
+export const decodeTimetablefromBase64 = (
+	encodedBase64: string,
+): { courses: ReturnType<typeof useDetailedEnrolledCourses> } | null => {
+	try {
+		const jsonString = atob(encodedBase64);
+		const shareData = JSON.parse(jsonString);
+		return shareData;
+	} catch {
+		return null;
+	}
+};
+
+export const generateShareURL = (
+	courses: ReturnType<typeof useDetailedEnrolledCourses>,
+): string => {
+	const encoded = encodeTimetabletoBase64(courses);
+	const url: URL = new URL(window.location.href);
+	url.searchParams.set('share', 'true');
+	url.searchParams.set('ed', encoded);
+	return url.toString();
+};
+
+export const getMeetingsByDay = (
+	courses: ReturnType<typeof useDetailedEnrolledCourses>,
+): Record<string, SharedCalendarMeeting[]> => {
+	const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+	const meetingsByDay: Record<string, SharedCalendarMeetingInternal[]> = {};
+	days.forEach((day) => (meetingsByDay[day] = []));
+
+	courses.forEach((course) => {
+		course.classes.forEach((cls) => {
+			cls.meetings.forEach((meeting) => {
+				const day = meeting.day;
+				if (meetingsByDay[day]) {
+					const key = [
+						course.id,
+						cls.typeId,
+						cls.classNumber,
+						day,
+						meeting.time.start,
+						meeting.time.end,
+						meeting.location,
+						meeting.campus,
+					].join('|');
+
+					let group = meetingsByDay[day].find((m) => m._key === key);
+
+					if (!group) {
+						group = {
+							...meeting,
+							courseName: course.name.code ?? '',
+							classType: cls.type ?? '',
+							classNumber: cls.classNumber ?? '',
+							subject: course.name.subject ?? '',
+							title: course.name.title ?? '',
+							available_seats: cls.available_seats ?? '',
+							size: cls.size ?? '',
+							dateRanges: [],
+							_key: key,
+						};
+						meetingsByDay[day].push(group);
+					}
+					group.dateRanges.push({
+						start: meeting.date.start,
+						end: meeting.date.end,
+					});
+				}
+			});
+		});
+	});
+
+	const result: Record<string, SharedCalendarMeeting[]> = {};
+	Object.keys(meetingsByDay).forEach((day) => {
+		result[day] = meetingsByDay[day].map(({ _key, ...rest }) => rest);
+	});
+
+	return result;
+};

--- a/src/helpers/share.ts
+++ b/src/helpers/share.ts
@@ -1,4 +1,14 @@
+import dayjs from 'dayjs';
+
+import { COURSE_COLORS } from '../constants/course-colors';
 import type { useDetailedEnrolledCourses } from '../data/enrolled-courses';
+
+type ColorOptions = {
+	bg: string;
+	border: string;
+	text: string;
+	dot: string;
+};
 
 export type SharedCalendarMeeting = {
 	available_seats: string;
@@ -14,26 +24,27 @@ export type SharedCalendarMeeting = {
 	subject: string;
 	time: { start: string; end: string };
 	title: string;
+	color: ColorOptions;
 };
 
 type SharedCalendarMeetingInternal = SharedCalendarMeeting & { _key: string };
 
-const encodeTimetabletoBase64 = (
+const encodeTimetableToBase64 = (
 	courses: ReturnType<typeof useDetailedEnrolledCourses>,
 ): string => {
 	const shareData = {
 		courses,
 	};
 	const jsonString = JSON.stringify(shareData);
-	const base64 = btoa(jsonString);
+	const base64 = btoa(encodeURIComponent(jsonString));
 	return base64;
 };
 
-export const decodeTimetablefromBase64 = (
+export const decodeTimetableFromBase64 = (
 	encodedBase64: string,
 ): { courses: ReturnType<typeof useDetailedEnrolledCourses> } | null => {
 	try {
-		const jsonString = atob(encodedBase64);
+		const jsonString = decodeURIComponent(atob(encodedBase64));
 		const shareData = JSON.parse(jsonString);
 		return shareData;
 	} catch {
@@ -44,10 +55,10 @@ export const decodeTimetablefromBase64 = (
 export const generateShareURL = (
 	courses: ReturnType<typeof useDetailedEnrolledCourses>,
 ): string => {
-	const encoded = encodeTimetabletoBase64(courses);
+	const encoded = encodeTimetableToBase64(courses);
 	const url: URL = new URL(window.location.href);
 	url.searchParams.set('share', 'true');
-	url.searchParams.set('ed', encoded);
+	url.hash = `ed=${encoded}`;
 	return url.toString();
 };
 
@@ -57,6 +68,8 @@ export const getMeetingsByDay = (
 	const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
 	const meetingsByDay: Record<string, SharedCalendarMeetingInternal[]> = {};
 	days.forEach((day) => (meetingsByDay[day] = []));
+	const clrTracker: Map<string, ColorOptions> = new Map([]);
+	let clrIndex: number = 0;
 
 	courses.forEach((course) => {
 		course.classes.forEach((cls) => {
@@ -76,9 +89,18 @@ export const getMeetingsByDay = (
 
 					let group = meetingsByDay[day].find((m) => m._key === key);
 
+					if (!clrTracker.has(course.id)) {
+						clrTracker.set(course.id, COURSE_COLORS[clrIndex]);
+						clrIndex++;
+					}
+
 					if (!group) {
 						group = {
 							...meeting,
+							time: {
+								start: dayjs(meeting.time.start, 'HH:mm').format('h:mm A'),
+								end: dayjs(meeting.time.end, 'HH:mm').format('h:mm A'),
+							},
 							courseName: course.name.code ?? '',
 							classType: cls.type ?? '',
 							classNumber: cls.classNumber ?? '',
@@ -87,6 +109,7 @@ export const getMeetingsByDay = (
 							available_seats: cls.available_seats ?? '',
 							size: cls.size ?? '',
 							dateRanges: [],
+							color: clrTracker.get(course.id)!,
 							_key: key,
 						};
 						meetingsByDay[day].push(group);
@@ -102,7 +125,13 @@ export const getMeetingsByDay = (
 
 	const result: Record<string, SharedCalendarMeeting[]> = {};
 	Object.keys(meetingsByDay).forEach((day) => {
-		result[day] = meetingsByDay[day].map(({ _key, ...rest }) => rest);
+		result[day] = meetingsByDay[day]
+			.sort(
+				(a, b) =>
+					dayjs(a.time.start, 'h:mm A').valueOf() -
+					dayjs(b.time.start, 'h:mm A').valueOf(),
+			)
+			.map(({ _key, ...rest }) => rest);
 	});
 
 	return result;

--- a/src/locales/en-au.json
+++ b/src/locales/en-au.json
@@ -86,6 +86,7 @@
 			"November",
 			"December"
 		],
+		"shared": "Shared Timetable",
 		"immoveable-course": "Immoveable course",
 		"no-available-seats": "Class full",
 		"conflict": "Conflict with another class",
@@ -94,11 +95,16 @@
 			"copy": "Copy to clipboard",
 			"export": "Export to calendar",
 			"export-success": "Calendar file exported",
+			"share": "Share timetable",
 			"no-courses": "No courses to export",
 			"ready": "Ready for Enrolment",
 			"copy-success": "Copied to clipboard!",
 			"enrolment-instruction": "Copy the numbers below and enter them on the myEnrolment page. You can also export your classes to a calendar file."
 		}
+	},
+	"shared-timetable": {
+		"tooltip": "Open Shared Timetable",
+		"title": "Shared Timetable"
 	},
 	"help": {
 		"title": "How to use MyTimetable",

--- a/src/locales/zh-cn.json
+++ b/src/locales/zh-cn.json
@@ -39,13 +39,19 @@
 			"十一月",
 			"十二月"
 		],
+		"shared": "共享时间表",
 		"immoveable-course": "此课程无法移动",
 		"end-actions": {
 			"copy": "复制到剪切板",
 			"ready": "准备选课",
+			"share": "分享课程表",
 			"copy-success": "已成功复制到剪切板！",
 			"enrolment-instruction": "复制课程代号并前往 myEnrolment 的 Enrolment 页面输入以正式选课"
 		}
+	},
+	"shared-timetable": {
+		"tooltip": "开放共享时间表",
+		"title": "共享时间表"
 	},
 	"help": {
 		"title": "如何使用 MyTimetable",


### PR DESCRIPTION
### Description
Added feature allowing users to easily share their timetable via link.

### Changes Made
Added feature allowing users to easily share their timetable via link.

### Related Issues
Fixes https://github.com/compsci-adl/mytimetable/issues/38

### Additional Notes
1. This incorporates changes suggested by Justin in previous PR. 

2. The translations I added for i18n were all from google translate so might need to be checked, also there are plenty of other keywords that could also be translated.

3. The url length was an issue as the encoded data can be quite long as a url parameter it was sent in HTTP headers as refferer so I moved large encoded data from query params to URL hash to avoid 431 errors caused by refferer header size limits. This avoids header issues but is a temporary solution, ideally an URL shortener or some simple serverside storage would be preferable long-term. It is also not practical for users and some applications may string the URL hash from links
