### PR TITLE
fix: Run changelog workflow correctly for Renovate

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,11 +6,17 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, synchronize, labeled, unlabeled]
 
 jobs:
   update-changelog:
     name: Auto Changelog & Version Bump
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     permissions:
       contents: write
       pull-requests: read
@@ -70,7 +76,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit."
           else
-            git commit -m "chore: update CHANGELOG.md and bump version [skip ci]"
+            git commit -m "chore: update CHANGELOG.md and bump version"
             
             if [ "${{ github.event_name }}" = "push" ]; then
               git push origin HEAD:${{ github.ref }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -70,7 +70,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit."
           else
-            git commit -m "chore: update CHANGELOG.md and bump version"
+            git commit -m "chore: update CHANGELOG.md and bump version [skip ci]"
             
             if [ "${{ github.event_name }}" = "push" ]; then
               git push origin HEAD:${{ github.ref }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,8 +6,6 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
-  pull_request_target:
-    types: [opened, synchronize, labeled, unlabeled]
 
 jobs:
   update-changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3] - 2026-08-01
+
+### Changed
+
+- Remove pull_request_target trigger from changelog workflow ([#109](https://github.com/compsci-adl/mytimetable/pull/109))
+
+### Package Updates
+
+- Add gitIgnoredAuthors to Renovate config ([#109](https://github.com/compsci-adl/mytimetable/pull/109))
+
 ## [3.2.2] - 2026-08-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mytimetable",
 	"private": true,
-	"version": "3.2.2",
+	"version": "3.2.3",
 	"type": "module",
 	"scripts": {
 		"prepare": "simple-git-hooks",

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,11 @@
 	"automerge": true,
 	"automergeType": "pr",
 	"autoApprove": true,
+	"gitIgnoredAuthors": [
+		"github-actions[bot]",
+		"github-actions[bot]@users.noreply.github.com",
+		"41898282+github-actions[bot]@users.noreply.github.com"
+	],
 	"prConcurrentLimit": 1,
 	"prHourlyLimit": 0,
 	"separateMinorPatch": false,


### PR DESCRIPTION
### Description
Run changelog workflow correctly for Renovate

### Changes Made
- Add gitIgnoredAuthors to Renovate config
- Remove pull_request_target trigger from changelog workflow

### Related Issues
N/A

### Additional Notes
N/A
